### PR TITLE
Add Vite dev server proxy config and vite-proxy toggle script

### DIFF
--- a/MateCat-Noble/MateCatApache/Dockerfile
+++ b/MateCat-Noble/MateCatApache/Dockerfile
@@ -70,8 +70,10 @@ RUN #phpenmod mcrypt
 
 COPY run_plugin_js_build.sh /tmp/run_plugin_js_build.sh
 COPY run.sh /tmp/run.sh
+COPY vite-proxy.sh /usr/local/bin/vite-proxy
 RUN chmod +x /tmp/run_plugin_js_build.sh
 RUN chmod +x /tmp/run.sh
+RUN chmod +x /usr/local/bin/vite-proxy
 
 WORKDIR "/var/www/matecat"
 CMD ["/tmp/run.sh"]

--- a/MateCat-Noble/MateCatApache/data/etc/apache2/sites-enabled/443-matecat.conf
+++ b/MateCat-Noble/MateCatApache/data/etc/apache2/sites-enabled/443-matecat.conf
@@ -12,6 +12,7 @@
 
 
 <VirtualHost *:443>
+    #IncludeOptional /etc/apache2/vite-dev-proxy.inc
 
     ServerAdmin webmaster@localhost
     ServerName dev.matecat.com

--- a/MateCat-Noble/MateCatApache/data/etc/apache2/vite-dev-proxy.inc
+++ b/MateCat-Noble/MateCatApache/data/etc/apache2/vite-dev-proxy.inc
@@ -1,0 +1,44 @@
+# Vite dev server reverse proxy (included from VirtualHost)
+# Toggle with: vite-proxy on|off|status
+
+# Disable caching for proxied paths
+<LocationMatch "^/((@vite|@react-refresh|@fs|vite-entries|__vite_hmr|node_modules)(/|$))">
+    ExpiresActive Off
+    Header always unset Expires
+    Header always set Cache-Control "no-store"
+</LocationMatch>
+<LocationMatch "^/public/">
+    ExpiresActive Off
+    Header always unset Expires
+    Header always set Cache-Control "no-store"
+</LocationMatch>
+
+# HMR WebSocket
+RewriteCond %{HTTP:Upgrade} websocket [NC]
+RewriteCond %{HTTP:Connection} upgrade [NC]
+RewriteRule ^/__vite_hmr(.*)$ "ws://127.0.0.1:5173/__vite_hmr$1" [P,L]
+
+# Proxy Vite paths (before .htaccess static file serving)
+ProxyPass "/__vite_hmr" "ws://127.0.0.1:5173/__vite_hmr"
+ProxyPassReverse "/__vite_hmr" "ws://127.0.0.1:5173/__vite_hmr"
+ProxyPass "/@vite" "http://127.0.0.1:5173/@vite"
+ProxyPassReverse "/@vite" "http://127.0.0.1:5173/@vite"
+ProxyPass "/@react-refresh" "http://127.0.0.1:5173/@react-refresh"
+ProxyPassReverse "/@react-refresh" "http://127.0.0.1:5173/@react-refresh"
+ProxyPass "/@fs/" "http://127.0.0.1:5173/@fs/"
+ProxyPassReverse "/@fs/" "http://127.0.0.1:5173/@fs/"
+ProxyPass "/vite-entries/" "http://127.0.0.1:5173/vite-entries/"
+ProxyPassReverse "/vite-entries/" "http://127.0.0.1:5173/vite-entries/"
+ProxyPass "/public/" "http://127.0.0.1:5173/public/"
+ProxyPassReverse "/public/" "http://127.0.0.1:5173/public/"
+ProxyPass "/plugins/" "http://127.0.0.1:5173/plugins/"
+ProxyPassReverse "/plugins/" "http://127.0.0.1:5173/plugins/"
+ProxyPass "/node_modules/" "http://127.0.0.1:5173/node_modules/"
+ProxyPassReverse "/node_modules/" "http://127.0.0.1:5173/node_modules/"
+
+SetEnv VITE_DEV 1
+
+# Longer timeout for Vite (SCSS compilation can be slow on first load)
+<Proxy "http://127.0.0.1:5173/*">
+    ProxySet timeout=120
+</Proxy>

--- a/MateCat-Noble/MateCatApache/vite-proxy.sh
+++ b/MateCat-Noble/MateCatApache/vite-proxy.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Toggle Vite dev server reverse proxy in Apache
+# Usage: vite-proxy {on|off|status}
+
+CONF="/etc/apache2/sites-enabled/443-matecat.conf"
+ENABLED="IncludeOptional /etc/apache2/vite-dev-proxy.inc"
+DISABLED="#IncludeOptional /etc/apache2/vite-dev-proxy.inc"
+
+case "$1" in
+  on)
+    sed -i "s|${DISABLED}|${ENABLED}|" "$CONF" && apachectl graceful
+    echo "Vite dev proxy enabled. Run 'yarn watch' to start Vite."
+    ;;
+  off)
+    sed -i "s|${ENABLED}|${DISABLED}|" "$CONF" && apachectl graceful
+    echo "Vite dev proxy disabled. Apache serves static builds."
+    ;;
+  status)
+    if grep -q "^[[:space:]]*IncludeOptional.*/vite-dev-proxy.inc" "$CONF"; then
+      echo "ON"
+    else
+      echo "OFF"
+    fi
+    ;;
+  *)
+    echo "Usage: vite-proxy {on|off|status}"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary

- Adds Apache reverse proxy configuration (`vite-dev-proxy.inc`) for the Vite dev server — proxies HMR websocket, `@vite`, `@fs`, `@react-refresh`, `public/`, `plugins/`, `node_modules/`, `vite-entries/` to `localhost:5173` and sets `VITE_DEV` env var for PHP dev-mode asset injection
- Adds `#IncludeOptional` line (commented out by default) to `443-matecat.conf`
- Adds `vite-proxy` CLI script installed to `/usr/local/bin/` for toggling the proxy

## Usage

```bash
# Inside the container
vite-proxy on       # Enable Apache → Vite proxy + set VITE_DEV=1
yarn watch          # Start Vite dev server with HMR
# ... develop ...
vite-proxy off      # Disable proxy, serve static builds
vite-proxy status   # Check current state (ON/OFF)
```

## Context

Part of the Webpack → Vite migration for MateCat. The proxy configuration was previously applied manually inside running containers. This PR bakes it into the Docker image so it survives rebuilds.