### PR TITLE
macOS support: parameterized compose, named MySQL volumes, dump auto-restore, slave/Apache self-heal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,7 @@ Session.vim
 .directory
 oauth_config.ini
 MateCat-Xenial/MateCatApache/data/etc/letsencrypt
+
+.env
+.DS_Store
+temporary_docker_mount_volume/

--- a/MateCat-Noble/.env.example
+++ b/MateCat-Noble/.env.example
@@ -1,0 +1,23 @@
+# Copy this file to .env and adjust values for your host.
+# docker compose reads .env automatically from the same directory.
+
+# --- User mapping (set to your host uid/gid so bind-mounted files are owned by you) ---
+# Linux/macOS:  id -u  /  id -g
+docker_uid=1000
+docker_gid=1000
+
+# --- Container architecture ---
+# linux/amd64 forces x86_64 (Rosetta on Apple Silicon, native on Intel/AMD Linux).
+# Override to linux/arm64 if/when all upstream images publish ARM variants.
+DOCKER_PLATFORM=linux/amd64
+
+# --- Bind-mount paths ---
+# Path to your MateCat application checkout (git clone https://github.com/matecat/MateCat.git).
+MATECAT_SOURCE_PATH=../../MateCat
+
+# Path to a Let's Encrypt-style cert directory (self-signed or real). Mounted at /etc/letsencrypt.
+MATECAT_CERTS_PATH=../../MateCat/certs/letsencrypt
+
+# Path to a host directory used to inject SQL dumps into MySQL containers.
+# Drop a *-dump.sql file here and the master container will auto-restore it on first boot.
+TEMP_VOLUME_PATH=../temporary_docker_mount_volume

--- a/MateCat-Noble/MateCatApache/run.sh
+++ b/MateCat-Noble/MateCatApache/run.sh
@@ -101,6 +101,8 @@ pushd ./daemons || exit 1
 popd || exit 1
 
 echo "Starting Apache..."
+# Stale pid survives docker restart; service apache2 restart would skip start as "already running"
+rm -f /var/run/apache2/apache2.pid
 /etc/init.d/apache2 restart
 echo "Apache Started"
 

--- a/MateCat-Noble/MySQL/run.sh
+++ b/MateCat-Noble/MySQL/run.sh
@@ -43,41 +43,51 @@ if [[ -z "${MATECAT_EXISTS}" && "${_type_}" == "master" ]]; then
   done
 
   # MySql MateCat
-  git clone https://github.com/matecat/MateCat.git /tmp/matecat
+  DUMP_FILE=$(ls -1 /mnt/external_volume/*-dump.sql 2>/dev/null | head -1)
+  if [[ -n "${DUMP_FILE}" ]]; then
+    echo "Restoring from dump: ${DUMP_FILE}"
+    mysql -e "CREATE DATABASE IF NOT EXISTS matecat CHARACTER SET utf8 COLLATE utf8_general_ci;"
+    /usr/bin/mysql matecat < "${DUMP_FILE}"
+  else
+    git clone https://github.com/matecat/MateCat.git /tmp/matecat
+    echo "Executing: /usr/bin/mysql </tmp/matecat/lib/Model/matecat.sql"
+    /usr/bin/mysql </tmp/matecat/lib/Model/matecat.sql
+    rm -rf /tmp/matecat
+  fi
 
-  # Creating schema and fill some data
-  echo "Executing: /usr/bin/mysql </tmp/matecat/lib/Model/matecat.sql"
-  /usr/bin/mysql </tmp/matecat/lib/Model/matecat.sql
-  # clean
-  rm -rf /tmp/matecat
+elif [[ "${_type_}" == "slave" ]]; then
 
-elif [[ -z "${MATECAT_EXISTS}" && "${_type_}" == "slave" ]]; then
+  SLAVE_IO=$(mysql -e "SHOW SLAVE STATUS\G" 2>/dev/null | grep -i "Slave_IO_Running:" | awk '{print $NF}')
+  SLAVE_SQL=$(mysql -e "SHOW SLAVE STATUS\G" 2>/dev/null | grep -i "Slave_SQL_Running:" | awk '{print $NF}')
 
-  RET=1
-  while [[ RET -ne 0 ]]; do
+  if [[ "$SLAVE_IO" != "Yes" || "$SLAVE_SQL" != "Yes" ]]; then
+    echo "=> Slave replication not running (IO=${SLAVE_IO:-none} SQL=${SLAVE_SQL:-none}); re-establishing..."
 
-    echo "=> Waiting for confirmation of MySQL Master ready"
-    MYSQL_MASTER_GTID=$(mysql -uadmin -padmin -h mysql-master -e "SHOW MASTER STATUS\G" | grep -i "Executed_Gtid_Set:" | awk '{print $2}')
-    printf "*** MYSQL_MASTER_GTID: %s \n\n" "${MYSQL_MASTER_GTID}"
+    RET=1
+    while [[ RET -ne 0 ]]; do
 
-    if [[ -n "${MYSQL_MASTER_GTID}" ]]; then
-      RET=0
-    fi
+      echo "=> Waiting for confirmation of MySQL Master ready"
+      MYSQL_MASTER_GTID=$(mysql -uadmin -padmin -h mysql-master -e "SHOW MASTER STATUS\G" | grep -i "Executed_Gtid_Set:" | awk '{print $2}')
+      printf "*** MYSQL_MASTER_GTID: %s \n\n" "${MYSQL_MASTER_GTID}"
 
-    sleep 2
+      if [[ -n "${MYSQL_MASTER_GTID}" ]]; then
+        RET=0
+      fi
 
-  done
+      sleep 2
 
-  #Set Replication
-  echo "#Set Replication"
-  mysql -e "RESET MASTER"
-  mysql -e "STOP SLAVE; RESET SLAVE ALL;"
-  mysql -e "SET GLOBAL gtid_purged=\"${MYSQL_MASTER_GTID}\" ;"
-  mysql -e "CHANGE MASTER TO MASTER_HOST=\"mysql-master\", MASTER_USER=\"admin\", MASTER_PASSWORD=\"admin\", MASTER_AUTO_POSITION = 1; START SLAVE;"
+    done
 
-  sleep 1
-  SLAVE_STATUS=$(mysql -e "SHOW SLAVE STATUS \G")
-  printf "%s \n\n" "${SLAVE_STATUS}"
+    echo "#Set Replication"
+    mysql -e "STOP SLAVE; RESET SLAVE ALL;"
+    mysql -e "RESET MASTER;"
+    mysql -e "SET GLOBAL gtid_purged=\"${MYSQL_MASTER_GTID}\" ;"
+    mysql -e "CHANGE MASTER TO MASTER_HOST=\"mysql-master\", MASTER_USER=\"admin\", MASTER_PASSWORD=\"admin\", MASTER_AUTO_POSITION = 1; START SLAVE;"
+
+    sleep 1
+    SLAVE_STATUS=$(mysql -e "SHOW SLAVE STATUS \G")
+    printf "%s \n\n" "${SLAVE_STATUS}"
+  fi
 
 fi
 

--- a/MateCat-Noble/MySQL/run.sh
+++ b/MateCat-Noble/MySQL/run.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 
-chown mysql:mysql /var/lib/mysql/
+# macOS VirtioFS bind-mounts expose files as uid 0; mysqld runs as 'mysql'.
+chown -R mysql:mysql /var/lib/mysql/
+
+# Discard inherited server-uuid so this instance generates its own.
+rm -f /var/lib/mysql/auto.cnf
+
+find /var/lib/mysql -name '.DS_Store' -delete 2>/dev/null
+
 rm -rf /var/run/mysqld/mysqld.pid 2>/dev/null
 
 echo "Executing: mysqld --basedir=/usr --datadir=/var/lib/mysql --plugin-dir=/usr/lib/mysql/plugin --log-error=/var/log/mysql/error.log --open-files-limit=65535 --pid-file=/var/run/mysqld/mysqld.pid --socket=/var/run/mysqld/mysqld.sock --port=3306"

--- a/MateCat-Noble/README-MACOS.md
+++ b/MateCat-Noble/README-MACOS.md
@@ -1,0 +1,110 @@
+# Running MateCat-Noble on macOS
+
+This stack runs on macOS (Intel and Apple Silicon) with Docker Desktop. The notes below cover the parts that differ from a stock Linux setup.
+
+## 1. Prerequisites
+
+- Docker Desktop for Mac (recent release, VirtioFS file sharing enabled).
+- On Apple Silicon: enable **Use Rosetta for x86_64/amd64 emulation** in Docker Desktop settings (Settings → General). Several upstream images in this stack are amd64-only.
+- `gh` and `git` for normal repo workflow.
+
+## 2. One-time setup
+
+### 2.1 Environment file
+
+```sh
+cd MateCat-Noble
+cp .env.example .env
+```
+
+Edit `.env` and set, at minimum:
+
+```sh
+docker_uid=$(id -u)     # e.g. 501
+docker_gid=$(id -g)     # e.g. 20
+DOCKER_PLATFORM=linux/amd64
+MATECAT_SOURCE_PATH=/absolute/path/to/your/MateCat checkout
+MATECAT_CERTS_PATH=/absolute/path/to/cert/dir/letsencrypt
+TEMP_VOLUME_PATH=/absolute/path/to/a/scratch/dir
+```
+
+`TEMP_VOLUME_PATH` is mounted at `/mnt/external_volume` in the MySQL and ProxySQL containers. Drop a `*-dump.sql` file here to seed the database (see §5).
+
+### 2.2 Host name resolution
+
+Apache inside the matecat container serves the vhosts `dev.matecat.com` and `0.ajax.dev.matecat.com` through `3.ajax.dev.matecat.com`. Add them to `/etc/hosts`:
+
+```sh
+echo "127.0.0.1  dev.matecat.com 0.ajax.dev.matecat.com 1.ajax.dev.matecat.com 2.ajax.dev.matecat.com 3.ajax.dev.matecat.com" | sudo tee -a /etc/hosts
+sudo dscacheutil -flushcache && sudo killall -HUP mDNSResponder
+```
+
+Without these entries the browser returns `ERR_NAME_NOT_RESOLVED`.
+
+### 2.3 Certificates
+
+The matecat container expects a Let's Encrypt-style directory at `MATECAT_CERTS_PATH`. For local development a self-signed cert is fine; create one with `mkcert` or `openssl` and point `MATECAT_CERTS_PATH` at the directory containing `live/dev.matecat.com/{fullchain,privkey}.pem`.
+
+## 3. Start the stack
+
+```sh
+cd MateCat-Noble
+docker compose up -d
+```
+
+Open `https://dev.matecat.com/` (accept the self-signed warning the first time).
+
+## 4. MySQL storage: named volumes (not bind mounts)
+
+`mysql-master` and `mysql-slave` write to Docker-managed **named volumes** (`master-mysql-data`, `slave-mysql-data`), not to host folders. The reason:
+
+- macOS bind mounts go through VirtioFS, which rewrites file ownership. mysqld runs as `mysql` inside the container but sees files owned by your host uid, which can corrupt the InnoDB system tablespace on restart.
+- Named volumes live in the Docker Desktop VM (native Linux ext4). Permissions and `fsync` behave the same as on a real Linux host.
+
+Side effects:
+
+- You can no longer browse MySQL data files from Finder. Use `docker exec` for inspection and `mysqldump` for backup.
+- `docker compose down` keeps the volumes; data survives restarts. `docker compose down -v` or `docker volume rm matecat-noble_master-mysql-data matecat-noble_slave-mysql-data` deletes the volumes and triggers a fresh bootstrap on next start.
+
+## 5. Seeding the database from a dump
+
+Drop a `*-dump.sql` file into `TEMP_VOLUME_PATH` (the directory you pointed at in `.env`). On the next fresh boot of `mysql-master` the entrypoint detects an empty datadir and runs:
+
+```sh
+mysql -e "CREATE DATABASE IF NOT EXISTS matecat CHARACTER SET utf8 COLLATE utf8_general_ci;"
+mysql matecat < /mnt/external_volume/<first matching dump>.sql
+```
+
+The dump replicates to `mysql-slave` through the binlog. **The dump is only loaded when the `matecat` database does not exist** — normal restarts skip it.
+
+### Producing a portable dump from another MySQL
+
+`mysqldump` defaults are not replication-friendly. Either dump with the right flags:
+
+```sh
+mysqldump -uroot -p \
+  --single-transaction --routines --triggers --events \
+  --set-gtid-purged=OFF \
+  --default-character-set=utf8 \
+  matecat > matecat-dump.sql
+```
+
+Or strip the two offending lines from an existing dump before placing it in `TEMP_VOLUME_PATH`:
+
+```sh
+sed -i '' '/SET @@SESSION.SQL_LOG_BIN= 0;/d; /SET @@GLOBAL.GTID_PURGED=/d' matecat-dump.sql
+```
+
+Without these adjustments the slave ends up empty (binlog disabled during load) and/or the import aborts with `ERROR 1840: @@GLOBAL.GTID_PURGED can only be set when @@GLOBAL.GTID_EXECUTED is empty`.
+
+## 6. Slave restart auto-recovery
+
+`MySQL/run.sh` checks `Slave_IO_Running` / `Slave_SQL_Running` on every container start and, if either is not `Yes`, re-establishes replication against `mysql-master` automatically. No manual `RESET SLAVE` / `CHANGE MASTER` after a `docker restart matecat-mysql-slave`.
+
+## 7. Apache restart auto-recovery
+
+`MateCatApache/run.sh` removes `/var/run/apache2/apache2.pid` before `service apache2 restart`. On `docker restart matecat` the pid file from the previous container life survives in the writable layer; sysvinit would otherwise see it, conclude Apache is already running, and exit without starting anything. Symptoms: `Apache Started` in the log, no apache process, `curl` returns `000`.
+
+## 8. XDebug
+
+The matecat service injects `host.docker.internal` via `extra_hosts: ["host.docker.internal:host-gateway"]` and sets `XDEBUG_CONFIG=client_host=host.docker.internal`. Configure your IDE listener on port 9003 (XDebug 3 default). No `lo0` alias hack is required.

--- a/MateCat-Noble/docker-compose.yml
+++ b/MateCat-Noble/docker-compose.yml
@@ -6,6 +6,7 @@ services:
 
   base:
     image: ostico/matecat-noble-base-image
+    platform: ${DOCKER_PLATFORM:-linux/amd64}
     build: ./NobleBaseImage
 
       #   filters:
@@ -26,6 +27,7 @@ services:
 
   amq:
     build: ./AMQ/
+    platform: ${DOCKER_PLATFORM:-linux/amd64}
     container_name: matecat-amq
     ports:
       - "61613:61613"
@@ -42,12 +44,13 @@ services:
       context: ./MySQL/
       args:
         _type_: "master"
+    platform: ${DOCKER_PLATFORM:-linux/amd64}
     container_name: matecat-mysql-master
     ports:
      - "3307:3306"
     volumes:
-      - /home/hashashiyyin/PhpstormProjects/temporary_docker_mount_volume:/mnt/external_volume:rw
-      - /home/hashashiyyin/PhpstormProjects/matecat-db-master-data:/var/lib/mysql:rw
+     - ${TEMP_VOLUME_PATH:-../temporary_docker_mount_volume}:/mnt/external_volume:rw
+     - master-mysql-data:/var/lib/mysql:rw
     networks:
       matecat-network:
         aliases:
@@ -58,12 +61,13 @@ services:
       context: ./MySQL/
       args:
         _type_: "slave"
+    platform: ${DOCKER_PLATFORM:-linux/amd64}
     container_name: matecat-mysql-slave
     ports:
      - "3308:3306"
     volumes:
-      - /home/hashashiyyin/PhpstormProjects/temporary_docker_mount_volume:/mnt/external_volume:rw
-      - /home/hashashiyyin/PhpstormProjects/matecat-db-slave-data:/var/lib/mysql:rw
+      - ${TEMP_VOLUME_PATH:-../temporary_docker_mount_volume}:/mnt/external_volume:rw
+      - slave-mysql-data:/var/lib/mysql:rw
     depends_on:
       - mysql-master
     networks:
@@ -73,6 +77,7 @@ services:
 
   proxysql:
     build: ./ProxySQL/
+    platform: ${DOCKER_PLATFORM:-linux/amd64}
     container_name: matecat-proxysql
     ports:
       - "3306:3306"
@@ -80,7 +85,7 @@ services:
       - mysql-master
       - mysql-slave
     volumes:
-      - /home/hashashiyyin/PhpstormProjects/temporary_docker_mount_volume:/mnt/external_volume:rw
+      - ${TEMP_VOLUME_PATH:-../temporary_docker_mount_volume}:/mnt/external_volume:rw
     networks:
        - matecat-network
     depends_on:
@@ -112,18 +117,21 @@ services:
       args:
         USER_UID: ${docker_uid}
         USER_GID: ${docker_gid}
+    platform: ${DOCKER_PLATFORM:-linux/amd64}
     container_name: matecat
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
     ## Remove this environment block if you don't need it ##
-      XDEBUG_CONFIG: 172.19.0.1
+      XDEBUG_CONFIG: "client_host=host.docker.internal"
       FILTERS_ADDRESS: http://filters:8732/
       PHP_IDE_CONFIG: serverName=dev.matecat.com
 #      SMTP_HOST: localhost
 #      SMTP_PORT: 2637
     ## Remove this environment block if you don't need it ##
     volumes:
-      - /home/hashashiyyin/PhpstormProjects/matecat/certs/letsencrypt:/etc/letsencrypt:rw
-      - /home/hashashiyyin/PhpstormProjects/matecat:/var/www/matecat:rw
+      - ${MATECAT_CERTS_PATH:-../../MateCat/certs/letsencrypt}:/etc/letsencrypt:rw
+      - ${MATECAT_SOURCE_PATH:-../../MateCat}:/var/www/matecat:rw
     ports:
       - "80:80"
       - "443:443"
@@ -146,3 +154,7 @@ services:
       - amq
       - smtp4dev
 #      - filters
+
+volumes:
+  master-mysql-data:
+  slave-mysql-data:


### PR DESCRIPTION
## Summary

Makes the `MateCat-Noble` stack runnable on macOS (Intel and Apple Silicon) without per-developer edits to `docker-compose.yml`, and ships three self-healing fixes that are useful on any host.

All changes are opt-in: defaults preserve existing Linux x86_64 behavior. Tested end-to-end on macOS Sequoia (Apple Silicon, Docker Desktop with VirtioFS + Rosetta) — full stack boots from clean, restores a 264 MB SQL dump, master/slave replication healthy, `https://dev.matecat.com/` returns 200.

## Commits (6)

| Commit | What |
|---|---|
| `chore: ignore .env, .DS_Store, and temporary scratch dir` | Keep host-specific files out of the repo |
| `fix(mysql): bind-mount and server-uuid hygiene on container start` | Recursive `chown`, drop `auto.cnf`, prune stray `.DS_Store` — survives cross-host datadir moves and VirtioFS uid remapping |
| `feat(mysql): auto-restore *-dump.sql and self-heal slave replication` | Master seeds itself from `/mnt/external_volume/*-dump.sql` on first boot; slave checks `SHOW SLAVE STATUS` on every start and re-establishes replication if IO/SQL threads aren't running |
| `fix(apache): clear stale pid file before service restart` | `docker restart matecat` no longer leaves Apache silently dead because sysvinit reads a stale `apache2.pid` from the writable layer |
| `feat(compose): parameterize paths/platform, named MySQL volumes, XDEBUG via host.docker.internal` | All hardcoded host paths replaced with `${VAR:-default}`; MySQL data moves to named volumes (avoids VirtioFS corruption on macOS, neutral on Linux); XDEBUG uses `host.docker.internal` instead of a brittle bridge IP |
| `docs(macos): add macOS setup guide` | New `MateCat-Noble/README-MACOS.md` covering Rosetta, `/etc/hosts`, mysqldump flags, named volume rationale |

## Breaking changes

**One** behavior change to flag: `mysql-master` and `mysql-slave` now use **named volumes** (`master-mysql-data`, `slave-mysql-data`) instead of host bind mounts. Existing developers with data in the old `matecat-db-master-data` / `matecat-db-slave-data` bind paths will need to either:

- `mysqldump` the old data and let the new master auto-restore from `/mnt/external_volume/*-dump.sql`, or
- Override `volumes:` locally to keep the bind mount.

This is the macOS-blocking change — VirtioFS bind mounts intermittently corrupt the InnoDB system tablespace because uid-remapped files leave mysqld unable to read its own datadir on restart. Named volumes live in the Docker Desktop VM (native Linux ext4) and don't have this problem.

## Defaults preserve current Linux x86_64 behavior

```yaml
platform: ${DOCKER_PLATFORM:-linux/amd64}
- ${MATECAT_SOURCE_PATH:-../../MateCat}:/var/www/matecat:rw
- ${MATECAT_CERTS_PATH:-../../MateCat/certs/letsencrypt}:/etc/letsencrypt:rw
- ${TEMP_VOLUME_PATH:-../temporary_docker_mount_volume}:/mnt/external_volume:rw
```

A developer with no `.env` on Linux x86_64 keeps the same `linux/amd64` platform and gets relative-path bind mounts adjacent to the repo checkout (one level above `MateCat-Noble/`), instead of the previous hardcoded `/home/hashashiyyin/PhpstormProjects/...` paths.

## Verification

- `docker compose config` resolves to expected paths
- `docker compose up -d` from clean: 7 containers healthy, dump auto-restored (368 jobs / 108,235 segments / 325 projects on both master + slave, 0s lag)
- `docker restart matecat-mysql-slave` → log shows `=> Slave replication not running (IO=none SQL=none); re-establishing...` and replication is `Yes/Yes` within ~25s, no manual intervention
- `docker restart matecat` → Apache process exists, HTTPS returns 200
- `https://dev.matecat.com/` returns 200 in browser

## Out of scope

- `filters` service is still commented out (no functional change to its state).
- XDEBUG port left at IDE-side default (9003 for XDebug 3).
